### PR TITLE
feat: adicionado novo sprite de estrada e melhorias na lógica do chão

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -15,19 +15,24 @@ export class Game extends Scene {
 
     preload() {
         this.load.image("cloud", "assets/cloud.png");
+        this.load.image("road", "assets/road.png");
     }
 
     create() {
         this.camera = this.cameras.main;
         this.camera.setBackgroundColor("#353946");
 
-        this.ground = this.add.rectangle(
+        this.ground = this.add.tileSprite(
             this.scale.width / 2,
             this.scale.height - 20,
             this.scale.width,
-            40,
-            0x444444
+            20,
+            "road"
         );
+
+        this.ground.setScale(1, 1);
+
+        this.ground.setOrigin(0.5, 0.5);
 
         this.physics.add.existing(this.ground, true);
 
@@ -56,6 +61,10 @@ export class Game extends Scene {
 
     update(time, delta) {
         this.clouds.forEach((cloud) => cloud.update());
+
+        if (this.ground) {
+            this.ground.tilePositionX += 2;
+        }
 
         if (this.player) {
             this.player.update();

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -24,9 +24,9 @@ export class Game extends Scene {
 
         this.ground = this.add.tileSprite(
             this.scale.width / 2,
-            this.scale.height - 20,
+            this.scale.height - 50,
             this.scale.width,
-            20,
+            0,
             "road"
         );
 


### PR DESCRIPTION
Fiz as seguintes alterações no jogo para adicionar a imagem da estrada:

- Adicionei o carregamento da imagem "road.png" no método `preload()` usando `this.load.image("road", "assets/road.png")`;
- Substituí o código do retângulo do chão por um `tileSprite` que usa a imagem road.png. O `tileSprite` permite que a imagem se repita horizontalmente, criando um efeito de movimento contínuo na estrada.

Só que fazendo só essa modificação a estrada duplicou em **3** ai ficou esquisito demais kkk
 
**Para resolver** fiz três alterações principais para resolver o problema da duplicação do chão:

- Reduzi a altura do `tileSprite` de 40 para 20 pixels. Isso ajuda a evitar que a imagem seja esticada verticalmente, o que pode causar essa duplicação visual.
- Adicionei `this.ground.setScale(1, 1)` para garantir que a escala da imagem esteja em **1:1** e não esteja sendo esticada.
- Adicionei `this.ground.setOrigin(0.5, 0.5)` para centralizar a origem da textura, o que ajuda a posicionar corretamente a imagem e evitar duplicações.

Agora o jogo tem um chão :D 

![{00628FE8-DD52-4257-93C8-15C44C52E146}](https://github.com/user-attachments/assets/989b9d5a-fcca-47ff-b694-378fe787f1a3)